### PR TITLE
feat: add wrapper paks around built-in Trimui Brick apps

### DIFF
--- a/Tools/tg3040/FN Editor.pak/launch.sh
+++ b/Tools/tg3040/FN Editor.pak/launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "$0" "$@"
+progdir="$(dirname "$0")"
+cd "$progdir" || exit 1
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$progdir"
+echo 1 >/tmp/stay_awake
+trap "rm -f /tmp/stay_awake" EXIT INT TERM HUP QUIT
+
+/usr/trimui/apps/fn_editor/launch.sh

--- a/Tools/tg3040/Moonlight.pak/launch.sh
+++ b/Tools/tg3040/Moonlight.pak/launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "$0" "$@"
+progdir="$(dirname "$0")"
+cd "$progdir" || exit 1
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$progdir"
+echo 1 >/tmp/stay_awake
+trap "rm -f /tmp/stay_awake" EXIT INT TERM HUP QUIT
+
+/usr/trimui/apps/moonlight/launch.sh

--- a/Tools/tg3040/USB Mass Storage.pak/launch.sh
+++ b/Tools/tg3040/USB Mass Storage.pak/launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "$0" "$@"
+progdir="$(dirname "$0")"
+cd "$progdir" || exit 1
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$progdir"
+echo 1 >/tmp/stay_awake
+trap "rm -f /tmp/stay_awake" EXIT INT TERM HUP QUIT
+
+/usr/trimui/apps/usb_storage/launch.sh


### PR DESCRIPTION
This simply re-executes the built-in apps.

Sources:

- [josegonzalez/trimui-brick-fn-editor-pak](https://github.com/josegonzalez/trimui-brick-fn-editor-pak)
- [josegonzalez/trimui-brick-usb-mass-storage-pak](https://github.com/josegonzalez/trimui-brick-usb-mass-storage-pak)
- [josegonzalez/trimui-brick-moonlight-pak](https://github.com/josegonzalez/trimui-brick-moonlight-pak)