### PR TITLE
Update Emus PICO tg3040 launch.sh - PICO8_Wrapper does not need to be…

### DIFF
--- a/Emus/tg3040/PICO.pak/launch.sh
+++ b/Emus/tg3040/PICO.pak/launch.sh
@@ -7,9 +7,9 @@ LOOP_PID=$!
 
 export picodir=/mnt/SDCARD/Emus/$PLATFORM/PICO.pak/PICO8_Wrapper
 cd $picodir
-export PATH=$PATH:$PWD/bin
+export PATH=$PWD/bin:$PATH
 export HOME=$picodir
-export PATH=${picodir}:$PATH
+#export PATH=${picodir}:$PATH
 export LD_LIBRARY_PATH="$picodir/lib:/usr/lib:$LD_LIBRARY_PATH"
 
 if ! [ -f /mnt/SDCARD/Emus/$PLATFORM/PICO.pak/PICO8_Wrapper/bin/pico8_64 ] || ! [ -f /mnt/SDCARD/Emus/$PLATFORM/PICO.pak/PICO8_Wrapper/bin/pico8.dat ]; then


### PR DESCRIPTION
… in PATH

Comment out line prepending $picodir to PATH, update the line that adds PICO8_Wrapper/bin to prepend to PATH as opposed to appending