### PR TITLE
[Pico-8 Splore] Fix the hack around `wget` to make game downloads actually work

### DIFF
--- a/Tools/tg3040/PICO.pak/PICO8_Wrapper/bin/wget
+++ b/Tools/tg3040/PICO.pak/PICO8_Wrapper/bin/wget
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 curl -L -k "$1" -q -o "$4" # > /mnt/sdcard/Tools/rg35xxplus/Splore.pak/wget.log 2>&1

--- a/Tools/tg5040/PICO.pak/PICO8_Wrapper/bin/wget
+++ b/Tools/tg5040/PICO.pak/PICO8_Wrapper/bin/wget
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 curl -L -k "$1" -q -o "$4" # > /mnt/sdcard/Tools/rg35xxplus/Splore.pak/wget.log 2>&1


### PR DESCRIPTION
## The issue that this PR tries to address

Pico-8 Splore still doesn't work (failing to download games), despite [the previous attempt](https://github.com/ryanmsartor/TrimUI-Brick-and-Smart-Pro-Custom-MinUI-Paks/commit/6aa41abf836537c49c0c18dfa0d68dd39a9d93dc) to use `curl` instead of `wget`.

## The solution

The trick was good 👍, but failed only because `bash` is not available on Trimui, leading `wget` call to fall back to the original `/usr/bin/wget`, which does not work with `HTTPS`.

Simply changing `bash` by `sh` in the script's shebang makes it work properly.

So now, **Splore** finally works on Trimui Brick! (Tested on mine at least) :tada:

Thanks for all your hard work BTW @ryanmsartor 👍